### PR TITLE
Fix full-run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Magenta ApS',
     author_email='info@magenta.dk',
     license="MPL 2.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     package_data={
         '': ["*.txt", "*.xml"]
     },


### PR DESCRIPTION
I ran into some issues with this (and other) dependencies installing a `tests` package which is not only wrong, but also breaks `./flask.sh full-run` in `os2mo`.