### PR TITLE
relax requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ setup(
     },
     zip_safe=False,
     install_requires=[
-        "python3-saml~=1.4.1",
-        "flask~=1.0.2",
-        "Flask-Session~=0.3.1",
-        "requests~=2.20.0",
-        "Flask-SQLAlchemy~=2.3.2",
-        "itsdangerous<1.0.0"
+        "python3-saml>=1.4",
+        "flask>=1.0",
+        "Flask-Session>=0.3",
+        "requests>=2.19",
+        "Flask-SQLAlchemy>=2.3",
+        "itsdangerous>=1.1"
 
     ],
     tests_require=[


### PR DESCRIPTION
This package is far too aggressive in its listed requirements: Given
that other packages depend on it, it should simply list what it needs,
and let _them_ handle any further breakage, as required.

As an example, `oio_rest` currently requires an `itsdangerous` that's
newer than the 1.0 this package explicitly says isn't good enough.