### PR TITLE
Fix bug where _prepare_flask_request received the wrong config

### DIFF
--- a/flask_saml_sso/sso.py
+++ b/flask_saml_sso/sso.py
@@ -147,7 +147,7 @@ def _prepare_saml_auth(func):
         if not config:
             config = _get_saml_settings(app)
             app.extensions['saml'] = config
-        req = _prepare_flask_request(config)
+        req = _prepare_flask_request(app.config)
         auth = OneLogin_Saml2_Auth(req, config)
         return func(auth)
 

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -421,3 +421,14 @@ class TestSSO(TestCase):
             actual_request = sso._prepare_flask_request(self.app.config)
 
         self.assertEqual(expected_request, actual_request)
+
+    @patch(
+        'flask_saml_sso.sso._prepare_flask_request', wraps=sso._prepare_flask_request
+    )
+    @freezegun.freeze_time('2019-01-01')
+    def test_prepare_flask_request_is_called_correctly_internally(self, mock):
+        """Ensure _prepare_flask_request is called correctly internally"""
+        self.app.config['SAML_FORCE_HTTPS'] = True
+        self.client.get('/saml/metadata/')
+
+        mock.assert_called_with(self.app.config)


### PR DESCRIPTION
This caused https override to not work.