### PR TITLE
Allow fetching metadata without needing to set IdP settings

### DIFF
--- a/flask_saml_sso/base.py
+++ b/flask_saml_sso/base.py
@@ -1,7 +1,7 @@
 import functools
-import requests
 
 import flask
+import requests
 from werkzeug import exceptions
 
 from . import session

--- a/flask_saml_sso/session.py
+++ b/flask_saml_sso/session.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import logging
 
 import flask
 from flask_session import sessions
@@ -11,6 +12,8 @@ SAML_NAME_ID = 'samlNameId'
 SAML_ATTRIBUTES = 'samlAttributes'
 SAML_SESSION_TYPE = 'samlSessionType'
 
+logger = logging.getLogger('flask_saml_sso')
+
 
 class SessionType(enum.Enum):
     User = 1
@@ -18,8 +21,6 @@ class SessionType(enum.Enum):
 
 
 def create_session_dict(session_type: SessionType, attributes: dict):
-    logger = flask.current_app.logger.getChild('sso')
-
     session_dict = {
         SAML_SESSION_TYPE: session_type,
         SAML_ATTRIBUTES: attributes,

--- a/flask_saml_sso/session.py
+++ b/flask_saml_sso/session.py
@@ -12,7 +12,7 @@ SAML_NAME_ID = 'samlNameId'
 SAML_ATTRIBUTES = 'samlAttributes'
 SAML_SESSION_TYPE = 'samlSessionType'
 
-logger = logging.getLogger('flask_saml_sso')
+logger = logging.getLogger(__name__)
 
 
 class SessionType(enum.Enum):

--- a/flask_saml_sso/settings.py
+++ b/flask_saml_sso/settings.py
@@ -1,0 +1,124 @@
+import logging
+
+import flask
+from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
+
+logger = logging.getLogger('flask_saml_sso')
+
+
+def _get_saml_sp_settings(app):
+    config = app.config.copy()
+
+    name_id_format = config.setdefault(
+        'SAML_NAME_ID_FORMAT', 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
+    )
+    force_https = config.setdefault('SAML_FORCE_HTTPS', False)
+
+    cert_file = config.setdefault('SAML_CERT_FILE', None)
+    key_file = config.setdefault('SAML_KEY_FILE', None)
+    requests_signed = config.setdefault('SAML_REQUESTS_SIGNED', False)
+
+    sp_settings = {
+        "sp": {
+            "entityId": flask.url_for(
+                'sso.metadata', _external=True, _scheme='https' if force_https else None
+            ),
+            "assertionConsumerService": {
+                "url": flask.url_for(
+                    'sso.acs', _external=True, _scheme='https' if force_https else None
+                ),
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            },
+            "singleLogoutService": {
+                "url": flask.url_for(
+                    'sso.sls', _external=True, _scheme='https' if force_https else None
+                ),
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            "NameIDFormat": name_id_format,
+        }
+    }
+
+    if requests_signed:
+        try:
+            with open(cert_file, 'r') as cf:
+                cert = cf.read()
+        except OSError:
+            logger.exception('Unable to read cert file {}'.format(cert_file))
+            raise
+
+        try:
+            with open(key_file, 'r') as kf:
+                key = kf.read()
+        except OSError:
+            logger.exception('Unable to read key file {}'.format(key_file))
+            raise
+
+        sp_settings['sp'].update({"x509cert": cert, "privateKey": key})
+
+    return sp_settings
+
+
+def _get_saml_idp_settings(app):
+    config = app.config.copy()
+
+    saml_idp_metadata_file = config.setdefault('SAML_IDP_METADATA_FILE', None)
+    saml_idp_metadata_url = config.setdefault('SAML_IDP_METADATA_URL', None)
+    insecure = config.setdefault('SAML_IDP_INSECURE', False)
+
+    if saml_idp_metadata_file:
+        with open(saml_idp_metadata_file, 'r') as idp:
+            idp_settings = OneLogin_Saml2_IdPMetadataParser.parse(idp.read())
+    else:
+        idp_settings = OneLogin_Saml2_IdPMetadataParser.parse_remote(
+            saml_idp_metadata_url, validate_cert=not insecure
+        )
+
+    return idp_settings
+
+
+def _get_saml_security_settings(app):
+    config = app.config.copy()
+
+    signature_algorithm = config.setdefault(
+        'SAML_SIGNATURE_ALGORITHM', 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+    )
+    digest_algorithm = config.setdefault(
+        'SAML_DIGEST_ALGORITHM', 'http://www.w3.org/2001/04/xmlenc#sha256'
+    )
+    requests_signed = config.setdefault('SAML_REQUESTS_SIGNED', False)
+    want_name_id = config.setdefault('SAML_WANT_NAME_ID', True)
+    want_attribute_statement = config.setdefault('SAML_WANT_ATTRIBUTE_STATEMENT', False)
+    requested_authn_context = config.setdefault('SAML_REQUESTED_AUTHN_CONTEXT', True)
+    requested_authn_context_comparison = config.setdefault(
+        'SAML_REQUESTED_AUTHN_CONTEXT_COMPARISON', 'exact'
+    )
+
+    return {
+        "security": {
+            "authnRequestsSigned": requests_signed,
+            "logoutRequestSigned": requests_signed,
+            "signatureAlgorithm": signature_algorithm,
+            "digestAlgorithm": digest_algorithm,
+            "wantNameId": want_name_id,
+            "wantAttributeStatement": want_attribute_statement,
+            "requestedAuthnContext": requested_authn_context,
+            "requestedAuthnContextComparison": requested_authn_context_comparison,
+        }
+    }
+
+
+def get_saml_settings(app, idp=True):
+    """Generate the internal config file for OneLogin"""
+    config = app.config.copy()
+    strict = config.setdefault('SAML_STRICT', True)
+    debug = config.setdefault('SAML_DEBUG', False)
+
+    s = {"strict": strict, "debug": debug}
+
+    if idp:
+        s.update(_get_saml_idp_settings(app))
+    s.update(_get_saml_security_settings(app))
+    s.update(_get_saml_sp_settings(app))
+
+    return s

--- a/flask_saml_sso/settings.py
+++ b/flask_saml_sso/settings.py
@@ -3,7 +3,7 @@ import logging
 import flask
 from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
 
-logger = logging.getLogger('flask_saml_sso')
+logger = logging.getLogger(__name__)
 
 
 def _get_saml_sp_settings(app):

--- a/flask_saml_sso/settings.py
+++ b/flask_saml_sso/settings.py
@@ -18,21 +18,20 @@ def _get_saml_sp_settings(app):
     key_file = config.setdefault('SAML_KEY_FILE', None)
     requests_signed = config.setdefault('SAML_REQUESTS_SIGNED', False)
 
+    # If not forcing HTTPS, set to None, to make url_for handle it on its own
+    url_scheme = 'https' if force_https else None
+
     sp_settings = {
         "sp": {
             "entityId": flask.url_for(
-                'sso.metadata', _external=True, _scheme='https' if force_https else None
+                'sso.metadata', _external=True, _scheme=url_scheme
             ),
             "assertionConsumerService": {
-                "url": flask.url_for(
-                    'sso.acs', _external=True, _scheme='https' if force_https else None
-                ),
+                "url": flask.url_for('sso.acs', _external=True, _scheme=url_scheme),
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
             },
             "singleLogoutService": {
-                "url": flask.url_for(
-                    'sso.sls', _external=True, _scheme='https' if force_https else None
-                ),
+                "url": flask.url_for('sso.sls', _external=True, _scheme=url_scheme),
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
             },
             "NameIDFormat": name_id_format,

--- a/flask_saml_sso/sso.py
+++ b/flask_saml_sso/sso.py
@@ -22,7 +22,7 @@ from werkzeug import exceptions
 from . import session
 from . import settings
 
-logger = logging.getLogger('flask_saml_sso')
+logger = logging.getLogger(__name__)
 
 basedir = os.path.dirname(__file__)
 

--- a/flask_saml_sso/sso.py
+++ b/flask_saml_sso/sso.py
@@ -58,15 +58,15 @@ def _create_saml_auth_decorator(func, key, idp_enabled):
     @functools.wraps(func)
     def wrapper():
         app = flask.current_app
-        saml_config = app.extensions.setdefault('saml', {})
-        saml_settings = saml_config.get(key)
+        saml_app_extension = app.extensions.setdefault('saml', {})
+        saml_settings = saml_app_extension.get(key)
         if not saml_settings:
-            config = settings.get_saml_settings(app, idp=idp_enabled)
+            settings_dict = settings.get_saml_settings(app, idp=idp_enabled)
             saml_settings = OneLogin_Saml2_Settings(
-                config, sp_validation_only=not idp_enabled
+                settings_dict, sp_validation_only=not idp_enabled
             )
-            saml_config[key] = saml_settings
-            logger.debug('SAML Metadata Settings ({}): \n{}'.format(key, config))
+            saml_app_extension[key] = saml_settings
+            logger.debug('SAML Metadata Settings ({}): \n{}'.format(key, settings_dict))
 
         req = _prepare_flask_request(app.config)
         auth = OneLogin_Saml2_Auth(req, saml_settings)

--- a/flask_saml_sso/sso.py
+++ b/flask_saml_sso/sso.py
@@ -6,126 +6,31 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 import contextlib
+import functools
+import logging
 import os
 from urllib import parse
 
 import flask
-import functools
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
-from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
 from onelogin.saml2.response import OneLogin_Saml2_Response
+from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
 from werkzeug import exceptions
 
 from . import session
+from . import settings
+
+logger = logging.getLogger('flask_saml_sso')
 
 basedir = os.path.dirname(__file__)
 
 blueprint = flask.Blueprint('sso', __name__, static_url_path='', url_prefix='/saml')
 
 
-def _get_logger():
-    return flask.current_app.logger.getChild('sso')
-
-
 def _build_error_response(message):
     return flask.jsonify(message), 401
-
-
-def _get_saml_settings(app):
-    """Generate the internal config file for OneLogin"""
-    logger = _get_logger()
-    config = app.config.copy()
-
-    insecure = config.setdefault('SAML_IDP_INSECURE', False)
-    force_https = config.setdefault('SAML_FORCE_HTTPS', False)
-    name_id_format = config.setdefault(
-        'SAML_NAME_ID_FORMAT', 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
-    )
-    cert_file = config.setdefault('SAML_CERT_FILE', None)
-    key_file = config.setdefault('SAML_KEY_FILE', None)
-    signature_algorithm = config.setdefault(
-        'SAML_SIGNATURE_ALGORITHM', 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-    )
-    digest_algorithm = config.setdefault(
-        'SAML_DIGEST_ALGORITHM', 'http://www.w3.org/2001/04/xmlenc#sha256'
-    )
-    requests_signed = config.setdefault('SAML_REQUESTS_SIGNED', False)
-    want_name_id = config.setdefault('SAML_WANT_NAME_ID', True)
-    want_attribute_statement = config.setdefault('SAML_WANT_ATTRIBUTE_STATEMENT', False)
-    saml_idp_metadata_file = config.setdefault('SAML_IDP_METADATA_FILE', None)
-    saml_idp_metadata_url = config.setdefault('SAML_IDP_METADATA_URL', None)
-    requested_authn_context = config.setdefault('SAML_REQUESTED_AUTHN_CONTEXT', True)
-    requested_authn_context_comparison = config.setdefault(
-        'SAML_REQUESTED_AUTHN_CONTEXT_COMPARISON', 'exact'
-    )
-    strict = config.setdefault('SAML_STRICT', True)
-    debug = config.setdefault('SAML_DEBUG', False)
-
-    if saml_idp_metadata_file:
-        with open(saml_idp_metadata_file, 'r') as idp:
-            remote = OneLogin_Saml2_IdPMetadataParser.parse(idp.read())
-    else:
-        remote = OneLogin_Saml2_IdPMetadataParser.parse_remote(
-            saml_idp_metadata_url, validate_cert=not insecure
-        )
-
-    s = {
-        "strict": strict,
-        "debug": debug,
-        "sp": {
-            "entityId": flask.url_for(
-                'sso.metadata', _external=True, _scheme='https' if force_https else None
-            ),
-            "assertionConsumerService": {
-                "url": flask.url_for(
-                    'sso.acs', _external=True, _scheme='https' if force_https else None
-                ),
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-            },
-            "singleLogoutService": {
-                "url": flask.url_for(
-                    'sso.sls', _external=True, _scheme='https' if force_https else None
-                ),
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-            },
-            "NameIDFormat": name_id_format,
-        },
-        "security": {
-            "authnRequestsSigned": requests_signed,
-            "logoutRequestSigned": requests_signed,
-            "signatureAlgorithm": signature_algorithm,
-            "digestAlgorithm": digest_algorithm,
-            "wantNameId": want_name_id,
-            "wantAttributeStatement": want_attribute_statement,
-            "requestedAuthnContext": requested_authn_context,
-            "requestedAuthnContextComparison": requested_authn_context_comparison,
-        },
-    }
-
-    s.setdefault('idp', {}).update(remote.get('idp'))
-
-    if requests_signed:
-        try:
-            with open(cert_file, 'r') as cf:
-                cert = cf.read()
-        except OSError:
-            logger.exception('Unable to read cert file {}'.format(cert_file))
-            raise
-
-        try:
-            with open(key_file, 'r') as kf:
-                key = kf.read()
-        except OSError:
-            logger.exception('Unable to read key file {}'.format(key_file))
-            raise
-
-        s['sp'].update({"x509cert": cert, "privateKey": key})
-
-    logger.debug('SAML Settings: \n{}'.format(s))
-
-    return s
 
 
 def _prepare_flask_request(config):
@@ -147,21 +52,38 @@ def _prepare_flask_request(config):
     }
 
 
-def _prepare_saml_auth(func):
-    """Decorator to create and initialize the OneLogin SAML2 Auth client"""
+def _create_saml_auth_decorator(func, key, idp_enabled):
+    """Factory for creating auth decorators"""
 
     @functools.wraps(func)
     def wrapper():
         app = flask.current_app
-        config = app.extensions.get('saml')
-        if not config:
-            config = _get_saml_settings(app)
-            app.extensions['saml'] = config
+        saml_config = app.extensions.setdefault('saml', {})
+        saml_settings = saml_config.get(key)
+        if not saml_settings:
+            config = settings.get_saml_settings(app, idp=idp_enabled)
+            saml_settings = OneLogin_Saml2_Settings(
+                config, sp_validation_only=not idp_enabled
+            )
+            saml_config[key] = saml_settings
+            logger.debug('SAML Metadata Settings ({}): \n{}'.format(key, config))
+
         req = _prepare_flask_request(app.config)
-        auth = OneLogin_Saml2_Auth(req, config)
+        auth = OneLogin_Saml2_Auth(req, saml_settings)
         return func(auth)
 
     return wrapper
+
+
+def _prepare_metadata_auth(func):
+    """Decorator to create and initialize the OneLogin SAML2 Auth client without
+    IdP settings, for fetching metadata"""
+    return _create_saml_auth_decorator(func, 'metadata', idp_enabled=False)
+
+
+def _prepare_saml_auth(func):
+    """Decorator to create and initialize the OneLogin SAML2 Auth client"""
+    return _create_saml_auth_decorator(func, 'full', idp_enabled=True)
 
 
 @blueprint.route('/api-token/')
@@ -172,7 +94,6 @@ def api_token():
 
     If no user is currently logged in, redirect to SSO flow and return here
     """
-    logger = _get_logger()
     logger.debug('API-token called')
 
     if not flask.session.get(session.LOGGED_IN):
@@ -209,14 +130,13 @@ def api_token():
 
 
 @blueprint.route('/metadata/')
-@_prepare_saml_auth
+@_prepare_metadata_auth
 def metadata(auth):
     """
     SAML metadata endpoint
 
     Exposes XML configuration of the Service Provider
     """
-    logger = _get_logger()
     logger.debug('Metadata called')
 
     settings = auth.get_settings()
@@ -245,7 +165,6 @@ def sso(auth):
 
     Redirects user to IdP login page specified in metadata
     """
-    logger = _get_logger()
     logger.debug('SSO called')
 
     return_to = flask.request.args.get('next', flask.request.host_url)
@@ -266,7 +185,6 @@ def acs(auth):
 
     Called by IdP with SAML assertion when authentication has been performed
     """
-    logger = _get_logger()
     logger.debug('ACS called')
 
     with _allow_duplicate_attribute_names():
@@ -310,7 +228,6 @@ def slo(auth):
 
     Redirects user to IdP SLO specified in metadata
     """
-    logger = _get_logger()
     logger.debug('SLO called')
 
     name_id = flask.session.get(session.SAML_NAME_ID)
@@ -341,7 +258,6 @@ def sls(auth):
     Consumes LogoutResponse from IdP when logout has been performed, and
     sends user back to landing page
     """
-    logger = _get_logger()
     logger.debug('SLS called')
 
     # Process the SLO message received from IdP

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -301,6 +301,19 @@ class TestSSO(TestCase):
         self.assertEqual(expected_metadata, actual_metadata)
         self.assertIn(('Content-Type', 'text/xml'), list(r.headers))
 
+    @freezegun.freeze_time('2019-01-01')
+    def test_metadata_does_not_require_idp(self):
+        """Assert that we can fetch metadata without setting IdP"""
+        self.app.config['SAML_IDP_METADATA_FILE'] = None
+        self.app.config['SAML_IDP_METADATA_URL'] = None
+
+        r = self.client.get('/saml/metadata/')
+
+        expected_metadata = self.get_fixture('/sso/metadata.xml')
+        actual_metadata = str(r.data, 'utf-8')
+
+        self.assertEqual(expected_metadata, actual_metadata)
+
     @patch(
         'onelogin.saml2.settings.OneLogin_Saml2_Settings.validate_metadata',
         lambda *x, **y: ['ERROR 3', 'ERROR 4'],


### PR DESCRIPTION
Refactor settings to separate module

Rework logging slightly to use python standard framework directly,
to prevent having to deal with annoying flask context issues